### PR TITLE
Fix submit on blur for editable texts

### DIFF
--- a/app/routes/board.$id/components.tsx
+++ b/app/routes/board.$id/components.tsx
@@ -94,7 +94,9 @@ export function EditableText({
             inputRef.current?.value !== value &&
             inputRef.current?.value.trim() !== ""
           ) {
-            fetcher.submit(event.currentTarget);
+            fetcher.submit(
+              event.currentTarget.parentElement as HTMLFormElement,
+            );
           }
           setEdit(false);
         }}


### PR DESCRIPTION
Right now, if you change a board or column name and blur the text, you'll get a `Cannot submit element that is not <form>, <button>, or <input type="submit|image">` error and it won't submit the form.

I've fixed it by submitting the current target's parent element. What do you think about this solution?