### PR TITLE
Add DATABASE_URL setup instruction to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ```sh
 npm i
+echo DATABASE_URL=file:./dev.db > .env
 npx prisma migrate dev
 npm run dev
 ```


### PR DESCRIPTION
DATABASE_URL is a required environment variable.

Adds a one line instruction for setting that variable to `file:./dev.db`.

Chose `dev.db` (as the name) because it is already present in `.gitignore`.