### PR TITLE
Ignore dev.db SQLite sidecar files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ node_modules
 /build
 /public/build
 .env
-/prisma/dev.db
+/prisma/dev.db*


### PR DESCRIPTION
Generated files like `dev.db-journal` are not ignored by default.

Extending the `/prisma/dev.db` rule will also ignore files with SQLite suffixes (`dev.db-journal`).